### PR TITLE
feat: added ability to set custom job name with client name, brand and business unit

### DIFF
--- a/Dataflow/pipeline/main.py
+++ b/Dataflow/pipeline/main.py
@@ -29,6 +29,7 @@ from dataflow_helpers import vision_helper
 from local_helpers import cm_helper
 from local_helpers import gcs_read_helper
 from local_helpers import jobfile_helper
+from datetime import datetime
 
 TMP_PATH = 'tmp.yaml'
 CREDENTIALS_PATH = 'client_secrets.json'
@@ -42,11 +43,13 @@ root.setLevel(logging.INFO)
 jobfile = jobfile_helper.open_jobfile(TMP_PATH, delete=True)
 print(jobfile)
 
+job_name = f"job-{jobfile['run_details']['client']}-{jobfile['run_details']['brand']}-{jobfile['run_details']['business_unit']}-{datetime.today().strftime('%Y-%m-%d-%H-%M-%S')}"
 # set options for Dataflow session
 options = PipelineOptions()
 google_cloud_options = options.view_as(GoogleCloudOptions)
 google_cloud_options.region = jobfile['run_details']['job_region']
-google_cloud_options.job_name = jobfile['job_name']
+# use default job_name if custom name is not set. E.g. client, brand or business unit is "undefined".
+google_cloud_options.job_name = jobfile['job_name'] if "undefined" in job_name else job_name
 google_cloud_options.project = jobfile['run_details']['gcp_project']
 google_cloud_options.temp_location = jobfile['run_details']['temp_location']
 google_cloud_options.staging_location = (

--- a/Dataflow/run.py
+++ b/Dataflow/run.py
@@ -45,6 +45,16 @@ if __name__ == '__main__':
     parser.add_argument('--local', action='store_true',
                         dest='local', default=False,
                         help='run on local machine (for testing)')
+    parser.add_argument('--client', action='store',
+                        dest='client', type=str, default="undefined",
+                        help='client name. E.g. Coca Cola')
+    parser.add_argument('--brand', action='store',
+                        dest='brand', type=str, default="undefined",
+                        help='brand name. E.g. for Coca Cola it could be Fanta. If no brand set client name')
+    parser.add_argument('--business_unit', action='store',
+                        dest='business_unit', type=str, default="undefined",
+                        help='Business unit. E.g. dk-offices. If no business unit set to client name')
+
     args = parser.parse_args()
 
     jobfile = open_jobfile(args.jobfile)
@@ -54,6 +64,9 @@ if __name__ == '__main__':
 
     # insert runtime details into modified jobfile for main.py
     # main.py will read the jobfile from this tmp_file, then delete it
+    jobfile['run_details']['business_unit'] = args.business_unit
+    jobfile['run_details']['brand'] = args.brand
+    jobfile['run_details']['client'] = args.client
     jobfile['creative_source_details']['limit'] = args.limit
     with open(TMP_PATH, 'w') as tmp_file:
         yaml.safe_dump(jobfile, tmp_file, default_flow_style=False)


### PR DESCRIPTION

Added three new args for setting
* client name
* brand
* business unit

So it could be: Client name: `Coca Cola Company`, brand: `Fanta` and business unit: `dk-branch`. 
These are used to create a custom job name for the dataflow. 
`job-<client name>-<brand>-<business unit>-<datetime>`. E.g. `job-wunderman-map-dk-2021-01-01-12-00-00`